### PR TITLE
Panic on invalid column name

### DIFF
--- a/table.go
+++ b/table.go
@@ -1,5 +1,7 @@
 package sqlbuilder
 
+import "fmt"
+
 type Table struct {
 	name    string
 	columns []*BasicColumn
@@ -24,6 +26,8 @@ func (t *Table) C(name string) *BasicColumn {
 			return c
 		}
 	}
+
+	panic(fmt.Errorf("Requested column %s does not exist in table %s", name, t.name))
 
 	return nil
 }


### PR DESCRIPTION
This PR adds a panic when a user attempts to act on a column that has not been configured as being part of a table.

The previous behavior was a segmentation violation when attempting to build the query. While we have added a specific panic, the behavior is the same only the stack trace and error message are now useful.